### PR TITLE
Support configuring cookie's "secure" options

### DIFF
--- a/src/middleware/xsrf.js
+++ b/src/middleware/xsrf.js
@@ -18,7 +18,8 @@ const XSRF = (secret, options = {}) => {
       invalidTokenMessage: 'Invalid XSRF Token',
       invalidTokenStatusCode: Status.FORBIDDEN,
       excludedMethods: ['GET', 'HEAD', 'OPTIONS', 'TRACE'],
-      renewPostWrite: false
+      renewPostWrite: false,
+      secure: false
     },
     options
   )
@@ -37,7 +38,8 @@ const XSRF = (secret, options = {}) => {
       ctx.set(settings.xsrfHeaderName, token)
       // TODO Remove Cookie Supports.
       ctx.cookies.set(settings.xsrfCookieName, token, {
-        httpOnly: false
+        httpOnly: false,
+        secure: settings.secure
       })
     }
 

--- a/src/middleware/xsrf.js
+++ b/src/middleware/xsrf.js
@@ -11,18 +11,20 @@ const xsrfHeaderName = 'X-XSRF-Token'
 const XSRF = (secret, options = {}) => {
   assert(secret, 'XSRF secret is missing')
 
-  const settings = Object.assign(
-    {
-      xsrfCookieName,
-      xsrfHeaderName,
-      invalidTokenMessage: 'Invalid XSRF Token',
-      invalidTokenStatusCode: Status.FORBIDDEN,
-      excludedMethods: ['GET', 'HEAD', 'OPTIONS', 'TRACE'],
-      renewPostWrite: false,
+  const defaults = {
+    xsrfCookieName,
+    xsrfHeaderName,
+    invalidTokenMessage: 'Invalid XSRF Token',
+    invalidTokenStatusCode: Status.FORBIDDEN,
+    excludedMethods: ['GET', 'HEAD', 'OPTIONS', 'TRACE'],
+    renewPostWrite: false,
+    cookieAttributes: {
+      httpOnly: false,
       secure: false
-    },
-    options
-  )
+    }
+  }
+
+  const settings = Object.assign({}, defaults, options)
   // --------------------------------------------------
   // *NOTE* Wrapper to `csrf` options.
   // --------------------------------------------------
@@ -38,8 +40,7 @@ const XSRF = (secret, options = {}) => {
       ctx.set(settings.xsrfHeaderName, token)
       // TODO Remove Cookie Supports.
       ctx.cookies.set(settings.xsrfCookieName, token, {
-        httpOnly: false,
-        secure: settings.secure
+        ...settings.cookieAttributes
       })
     }
 


### PR DESCRIPTION
For security consideration, should allow to config whether to send this cookie only under HTTPS. 
Details: https://owasp.org/www-community/controls/SecureCookieAttribute#